### PR TITLE
Cast sz to uint32 to fix compilation on 32 bit (#1175)

### DIFF
--- a/value.go
+++ b/value.go
@@ -856,7 +856,11 @@ func (lf *logFile) open(path string, flags uint32) error {
 		return errFile(err, lf.path, "Unable to run file.Stat")
 	}
 	sz := fi.Size()
-	y.AssertTruef(sz <= math.MaxUint32, "file size: %d greater than %d", sz, math.MaxUint32)
+	y.AssertTruef(
+		sz <= math.MaxUint32,
+		"file size: %d greater than %d",
+		uint32(sz), uint32(math.MaxUint32),
+	)
 	lf.size = uint32(sz)
 	if sz < vlogHeaderSize {
 		// Every vlog file should have at least vlogHeaderSize. If it is less than vlogHeaderSize


### PR DESCRIPTION
`env GOOS=linux GOARCH=arm GOARM=7 go build` no longer fails with overflow.

Similar to commit fb0cdb858c78004b9db8f08e91bb713780b20445.

Signed-off-by: Christian Stewart <christian@paral.in>